### PR TITLE
React 16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
   "bugs": {
     "url": "https://github.com/reactabular/selectabular/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
@@ -68,13 +70,12 @@
     "eslint-plugin-react": "^6.7.1",
     "git-prepush-hook": "^1.0.1",
     "jest": "^17.0.3",
-    "react": "^15.4.1",
-    "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^15.4.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "rimraf": "^2.5.4"
   },
   "peerDependencies": {
-    "react": ">= 15.0.0 < 16.0.0"
+    "react": ">= 15.0.0 < 17.0.0"
   },
   "pre-push": [
     "test:all"

--- a/src/components/select.js
+++ b/src/components/select.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Select extends React.Component {
   constructor(props) {
@@ -41,12 +42,12 @@ class Select extends React.Component {
   }
 }
 Select.propTypes = {
-  children: React.PropTypes.any.isRequired,
-  selectedRowIndex: React.PropTypes.any,
-  onSelectRow: React.PropTypes.func.isRequired,
+  children: PropTypes.any.isRequired,
+  selectedRowIndex: PropTypes.any,
+  onSelectRow: PropTypes.func.isRequired,
   // TODO: Same as for table but this is enough for now
   // -> extract reactabular-types?
-  rows: React.PropTypes.any.isRequired
+  rows: PropTypes.any.isRequired
 };
 Select.defaultProps = {
   onSelectRow: () => {}


### PR DESCRIPTION
- Update peer dependencies to include React 16.
- Import PropTypes from prop-types package.